### PR TITLE
RIP, foolz

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ The AniTV module relies on the following Python modules:
 * `re` (standard Python library)
 * `requests` (should be in standard Python library)
 
+## Configuration
+The AniTV module requires configuration before it will function. The required configuration consists of:
+
+* The AniTV server to use
+  * (optional) The API key needed to connect to the AniTV server, if required by the server
+
+A default server was included with this module previously, but it shut down in October 2016. The only
+known replacement is http://tv.yuuki-chan.xyz/, which requires requesting an API key before use.
+
 ## Usage
 Commands & arguments:
 

--- a/anitv.py
+++ b/anitv.py
@@ -5,6 +5,7 @@ Licensed under the GPL v3.0 or later
 """
 
 from sopel.module import commands, example
+from sopel.config import ConfigurationError
 from sopel.config.types import StaticSection, ValidatedAttribute
 from sopel import formatting
 from datetime import datetime
@@ -21,7 +22,7 @@ arg_regexen = {
 
 
 class AniTVSection(StaticSection):
-    server = ValidatedAttribute('server', default='anitv.foolz.us')
+    server = ValidatedAttribute('server', default=None)
     api_key = ValidatedAttribute('api_key', default=None)
 
 
@@ -37,7 +38,7 @@ def setup(bot):
     bot.config.define_section('anitv', AniTVSection)
 
     if not bot.config.anitv.server:
-        api_url = 'http://anitv.foolz.us'  # define default in code because the default API requires no key
+        raise ConfigurationError("anitv server must be specified!");
     else:
         server = bot.config.anitv.server
         api_url = server if (server.startswith('http://') or server.startswith('https://')) else 'http://' + server


### PR DESCRIPTION
The foolz server has been down long enough, it's time to remove it from the defaults.

Add a long-overdue note to the README about configuration, with a pointer to the only
other AniTV server I've been able to find (well, that works) and a disclaimer that it
requires an API key.

Closes #11.