### PR TITLE
Skip results w/o station when filtering by channel

### DIFF
--- a/anitv.py
+++ b/anitv.py
@@ -88,7 +88,7 @@ def anitv(bot, trigger):
             bot.say(result['error'])
             return
         if args['chan']:
-            if args['chan'].lower() not in result['station'].lower():
+            if not result['station'] or args['chan'].lower() not in result['station'].lower():
                 continue
         if args['ep']:
             if args['ep'] != result['episode']:


### PR DESCRIPTION
If there is no `station` attribute, obviously the result can't match the search value. Fixes #16.